### PR TITLE
chore: change module.exports to export default in config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   extends: ["@commitlint/config-conventional"],
   rules: {
     "header-max-length": [0, "always", Infinity],


### PR DESCRIPTION
chore: change module.exports to export default in config